### PR TITLE
Lane localization will first find lanes in routing module

### DIFF
--- a/pgdrive/scene_creator/blocks/create_block_utils.py
+++ b/pgdrive/scene_creator/blocks/create_block_utils.py
@@ -227,7 +227,7 @@ def create_wave_lanes(
     :return: List[Circular lane]
     """
     angle = np.pi - 2 * np.arctan(wave_length / (2 * lateral_dist))
-    radius = wave_length / (2 * math.sinsin(angle))
+    radius = wave_length / (2 * math.sin(angle))
     circular_lane_1, pre_lane = create_bend_straight(
         pre_lane, 10, radius, angle, False if toward_left else True, lane_width, [LineType.NONE, LineType.NONE]
     )

--- a/pgdrive/scene_creator/vehicle/base_vehicle.py
+++ b/pgdrive/scene_creator/vehicle/base_vehicle.py
@@ -372,13 +372,10 @@ class BaseVehicle(DynamicElement):
         self.dist_to_left, self.dist_to_right = self._dist_to_route_left_right()
 
     def _dist_to_route_left_right(self):
-        current_reference_lane = self.routing_localization.current_ref_lanes[-1]
+        current_reference_lane = self.routing_localization.current_ref_lanes[0]
         _, lateral_to_reference = current_reference_lane.local_coordinates(self.position)
-        if lateral_to_reference < 0:
-            lateral_to_right = abs(lateral_to_reference) + self.routing_localization.get_current_lane_width() / 2
-        else:
-            lateral_to_right = self.routing_localization.get_current_lane_width() / 2 - abs(lateral_to_reference)
-        lateral_to_left = self.routing_localization.get_current_lateral_range() - lateral_to_right
+        lateral_to_left = lateral_to_reference + self.routing_localization.get_current_lane_width() / 2
+        lateral_to_right = self.routing_localization.get_current_lateral_range() - lateral_to_left
         return lateral_to_left, lateral_to_right
 
     @property

--- a/pgdrive/scene_creator/vehicle/base_vehicle.py
+++ b/pgdrive/scene_creator/vehicle/base_vehicle.py
@@ -52,12 +52,12 @@ class BaseVehicle(DynamicElement):
     WIDTH = None
 
     def __init__(
-        self,
-        pg_world: PGWorld,
-        vehicle_config: Union[dict, PGConfig] = None,
-        physics_config: dict = None,
-        random_seed: int = 0,
-        name: str = None,
+            self,
+            pg_world: PGWorld,
+            vehicle_config: Union[dict, PGConfig] = None,
+            physics_config: dict = None,
+            random_seed: int = 0,
+            name: str = None,
     ):
         """
         This Vehicle Config is different from self.get_config(), and it is used to define which modules to use, and
@@ -375,7 +375,8 @@ class BaseVehicle(DynamicElement):
         current_reference_lane = self.routing_localization.current_ref_lanes[0]
         _, lateral_to_reference = current_reference_lane.local_coordinates(self.position)
         lateral_to_left = lateral_to_reference + self.routing_localization.get_current_lane_width() / 2
-        lateral_to_right = self.routing_localization.get_current_lateral_range() - lateral_to_left
+        lateral_to_right = self.routing_localization.get_current_lateral_range(self.position,
+                                                                               self.pg_world) - lateral_to_left
         return lateral_to_left, lateral_to_right
 
     @property
@@ -439,8 +440,8 @@ class BaseVehicle(DynamicElement):
         if not lateral_norm * forward_direction_norm:
             return 0
         cos = (
-            (forward_direction[0] * lateral[0] + forward_direction[1] * lateral[1]) /
-            (lateral_norm * forward_direction_norm)
+                (forward_direction[0] * lateral[0] + forward_direction[1] * lateral[1]) /
+                (lateral_norm * forward_direction_norm)
         )
         # return cos
         # Normalize to 0, 1
@@ -713,7 +714,7 @@ class BaseVehicle(DynamicElement):
             ckpt_idx = routing._target_checkpoints_index
             for surrounding_v in surrounding_vs:
                 if surrounding_v.lane_index[:-1] == (routing.checkpoints[ckpt_idx[0]], routing.checkpoints[ckpt_idx[1]
-                                                                                                           ]):
+                ]):
                     if self.lane.local_coordinates(self.position)[0] - \
                             self.lane.local_coordinates(surrounding_v.position)[0] < 0:
                         self.front_vehicles.add(surrounding_v)
@@ -728,7 +729,7 @@ class BaseVehicle(DynamicElement):
 
     @classmethod
     def get_action_space_before_init(cls):
-        return gym.spaces.Box(-1.0, 1.0, shape=(2, ), dtype=np.float32)
+        return gym.spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
 
     def remove_display_region(self):
         if self.render:
@@ -763,12 +764,12 @@ class BaseVehicle(DynamicElement):
     def arrive_destination(self):
         long, lat = self.routing_localization.final_lane.local_coordinates(self.position)
         flag = (
-            self.routing_localization.final_lane.length - 5 < long < self.routing_localization.final_lane.length + 5
-        ) and (
-            self.routing_localization.get_current_lane_width() / 2 >= lat >=
-            (0.5 - self.routing_localization.get_current_lane_num()) *
-            self.routing_localization.get_current_lane_width()
-        )
+                       self.routing_localization.final_lane.length - 5 < long < self.routing_localization.final_lane.length + 5
+               ) and (
+                       self.routing_localization.get_current_lane_width() / 2 >= lat >=
+                       (0.5 - self.routing_localization.get_current_lane_num()) *
+                       self.routing_localization.get_current_lane_width()
+               )
         return flag
 
     @property

--- a/pgdrive/scene_creator/vehicle/base_vehicle.py
+++ b/pgdrive/scene_creator/vehicle/base_vehicle.py
@@ -52,12 +52,12 @@ class BaseVehicle(DynamicElement):
     WIDTH = None
 
     def __init__(
-            self,
-            pg_world: PGWorld,
-            vehicle_config: Union[dict, PGConfig] = None,
-            physics_config: dict = None,
-            random_seed: int = 0,
-            name: str = None,
+        self,
+        pg_world: PGWorld,
+        vehicle_config: Union[dict, PGConfig] = None,
+        physics_config: dict = None,
+        random_seed: int = 0,
+        name: str = None,
     ):
         """
         This Vehicle Config is different from self.get_config(), and it is used to define which modules to use, and
@@ -375,8 +375,9 @@ class BaseVehicle(DynamicElement):
         current_reference_lane = self.routing_localization.current_ref_lanes[0]
         _, lateral_to_reference = current_reference_lane.local_coordinates(self.position)
         lateral_to_left = lateral_to_reference + self.routing_localization.get_current_lane_width() / 2
-        lateral_to_right = self.routing_localization.get_current_lateral_range(self.position,
-                                                                               self.pg_world) - lateral_to_left
+        lateral_to_right = self.routing_localization.get_current_lateral_range(
+            self.position, self.pg_world
+        ) - lateral_to_left
         return lateral_to_left, lateral_to_right
 
     @property
@@ -440,8 +441,8 @@ class BaseVehicle(DynamicElement):
         if not lateral_norm * forward_direction_norm:
             return 0
         cos = (
-                (forward_direction[0] * lateral[0] + forward_direction[1] * lateral[1]) /
-                (lateral_norm * forward_direction_norm)
+            (forward_direction[0] * lateral[0] + forward_direction[1] * lateral[1]) /
+            (lateral_norm * forward_direction_norm)
         )
         # return cos
         # Normalize to 0, 1
@@ -714,7 +715,7 @@ class BaseVehicle(DynamicElement):
             ckpt_idx = routing._target_checkpoints_index
             for surrounding_v in surrounding_vs:
                 if surrounding_v.lane_index[:-1] == (routing.checkpoints[ckpt_idx[0]], routing.checkpoints[ckpt_idx[1]
-                ]):
+                                                                                                           ]):
                     if self.lane.local_coordinates(self.position)[0] - \
                             self.lane.local_coordinates(surrounding_v.position)[0] < 0:
                         self.front_vehicles.add(surrounding_v)
@@ -729,7 +730,7 @@ class BaseVehicle(DynamicElement):
 
     @classmethod
     def get_action_space_before_init(cls):
-        return gym.spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
+        return gym.spaces.Box(-1.0, 1.0, shape=(2, ), dtype=np.float32)
 
     def remove_display_region(self):
         if self.render:
@@ -764,12 +765,12 @@ class BaseVehicle(DynamicElement):
     def arrive_destination(self):
         long, lat = self.routing_localization.final_lane.local_coordinates(self.position)
         flag = (
-                       self.routing_localization.final_lane.length - 5 < long < self.routing_localization.final_lane.length + 5
-               ) and (
-                       self.routing_localization.get_current_lane_width() / 2 >= lat >=
-                       (0.5 - self.routing_localization.get_current_lane_num()) *
-                       self.routing_localization.get_current_lane_width()
-               )
+            self.routing_localization.final_lane.length - 5 < long < self.routing_localization.final_lane.length + 5
+        ) and (
+            self.routing_localization.get_current_lane_width() / 2 >= lat >=
+            (0.5 - self.routing_localization.get_current_lane_num()) *
+            self.routing_localization.get_current_lane_width()
+        )
         return flag
 
     @property

--- a/pgdrive/scene_creator/vehicle/base_vehicle.py
+++ b/pgdrive/scene_creator/vehicle/base_vehicle.py
@@ -799,3 +799,7 @@ class BaseVehicle(DynamicElement):
 
     def set_static(self, flag):
         self.chassis_np.node().setStatic(flag)
+
+    @property
+    def reference_lanes(self):
+        return self.routing_localization.current_ref_lanes

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -261,7 +261,7 @@ class RoutingLocalizationModule:
         return len(self.current_ref_lanes)
 
     def get_current_lane(self, ego_vehicle):
-        possible_lanes = ray_localization(ego_vehicle.position, ego_vehicle.pg_world, all_result=True)
+        possible_lanes = ray_localization(ego_vehicle.position, ego_vehicle.pg_world, return_all_result=True)
         for lane, index, l_1_dist in possible_lanes:
             if lane in self.current_ref_lanes:
                 return lane, index

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -102,7 +102,7 @@ class RoutingLocalizationModule:
 
     def update_navigation_localization(self, ego_vehicle):
         position = ego_vehicle.position
-        lane, lane_index = ray_localization(position, ego_vehicle.pg_world)
+        lane, lane_index = self.get_current_lane(ego_vehicle)
         if lane is None:
             lane, lane_index = ego_vehicle.lane, ego_vehicle.lane_index
             ego_vehicle.on_lane = False
@@ -246,15 +246,11 @@ class RoutingLocalizationModule:
     def get_current_lane_num(self) -> float:
         return self.map.config[self.map.LANE_NUM]
 
-    # def get_navigate_landmarks(self, distance):
-    #     ret = []
-    #     for L in range(len(self.checkpoints) - 1):
-    #         start = self.checkpoints[L]
-    #         end = self.checkpoints[L + 1]
-    #         target_lanes = self.map.road_network.graph[start][end]
-    #         idx = self.get_current_lane_num() // 2 - 1
-    #         ref_lane = target_lanes[idx]
-    #         for tll in range(3, int(ref_lane.length), 3):
-    #             check_point = ref_lane.position(tll, 0)
-    #             ret.append([check_point[0], -check_point[1]])
-    #     return ret
+    def get_current_lane(self, ego_vehicle):
+        possible_lanes = ray_localization(ego_vehicle.position, ego_vehicle.pg_world, all_result=True)
+        for lane, index, l_1_dist in possible_lanes:
+            if lane in self.current_ref_lanes:
+                return lane, index
+        return possible_lanes[0][:-1]
+
+

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -251,6 +251,6 @@ class RoutingLocalizationModule:
         for lane, index, l_1_dist in possible_lanes:
             if lane in self.current_ref_lanes:
                 return lane, index
-        return possible_lanes[0][:-1]
+        return possible_lanes[0][:-1] if len(possible_lanes)>0 else (None, None)
 
 

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -244,7 +244,7 @@ class RoutingLocalizationModule:
         return self.map.config[self.map.LANE_WIDTH]
 
     def get_current_lane_num(self) -> float:
-        return self.map.config[self.map.LANE_NUM]
+        return len(self.current_ref_lanes)
 
     def get_current_lane(self, ego_vehicle):
         possible_lanes = ray_localization(ego_vehicle.position, ego_vehicle.pg_world, all_result=True)

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -1,8 +1,9 @@
 import logging
 import math
-
+from pgdrive.scene_creator.blocks.bottleneck import Merge, Split
 import numpy as np
 from panda3d.core import BitMask32, LQuaternionf, TransparencyAttrib
+from pgdrive.scene_creator.lane.straight_lane import StraightLane
 from pgdrive.constants import COLLISION_INFO_COLOR, RENDER_MODE_ONSCREEN, CamMask
 from pgdrive.scene_creator.blocks.first_block import FirstBlock
 from pgdrive.scene_creator.lane.circular_lane import CircularLane
@@ -12,6 +13,7 @@ from pgdrive.utils import clip, norm, get_np_random
 from pgdrive.utils.asset_loader import AssetLoader
 from pgdrive.utils.pg_space import Parameter, BlockParameterSpace
 from pgdrive.utils.scene_utils import ray_localization
+from pgdrive.utils.coordinates_shift import panda_position
 
 
 class RoutingLocalizationModule:
@@ -33,6 +35,7 @@ class RoutingLocalizationModule:
         self.checkpoints = None
         self.final_lane = None
         self.current_ref_lanes = None
+        self.current_road = None
         self._target_checkpoints_index = None
         self._navi_info = np.zeros((self.navigation_info_dim, ))  # navi information res
 
@@ -99,6 +102,7 @@ class RoutingLocalizationModule:
         target_road_1_start = self.checkpoints[0]
         target_road_1_end = self.checkpoints[1]
         self.current_ref_lanes = self.map.road_network.graph[target_road_1_start][target_road_1_end]
+        self.current_road = Road(target_road_1_start,target_road_1_end)
 
     def update_navigation_localization(self, ego_vehicle):
         position = ego_vehicle.position
@@ -121,6 +125,7 @@ class RoutingLocalizationModule:
         target_lanes_1 = self.map.road_network.graph[target_road_1_start][target_road_1_end]
         target_lanes_2 = self.map.road_network.graph[target_road_2_start][target_road_2_end]
         self.current_ref_lanes = target_lanes_1
+        self.current_road = Road(target_road_1_start,target_road_1_end)
 
         self._navi_info.fill(0.0)
         half = self.navigation_info_dim // 2
@@ -236,9 +241,18 @@ class RoutingLocalizationModule:
     def __del__(self):
         logging.debug("{} is destroyed".format(self.__class__.__name__))
 
-    def get_current_lateral_range(self) -> float:
+    def get_current_lateral_range(self, current_position, pg_world) -> float:
         """Return the maximum lateral distance from left to right."""
-        return self.get_current_lane_width() * self.get_current_lane_num()
+        # special process for special block
+        current_block_id = self.current_road.block_ID()
+        if current_block_id == Split.ID or current_block_id == Merge.ID:
+            left_lane = self.current_ref_lanes[0]
+            assert isinstance(left_lane, StraightLane), "Reference lane should be straight lane here"
+            long, lat = left_lane.local_coordinates(current_position)
+            current_position = left_lane.position(long, -left_lane.width/2)
+            return self._ray_lateral_range(pg_world, current_position, self.current_ref_lanes[0].direction_lateral)
+        else:
+            return self.get_current_lane_width() * self.get_current_lane_num()
 
     def get_current_lane_width(self) -> float:
         return self.map.config[self.map.LANE_WIDTH]
@@ -252,3 +266,22 @@ class RoutingLocalizationModule:
             if lane in self.current_ref_lanes:
                 return lane, index
         return possible_lanes[0][:-1] if len(possible_lanes) > 0 else (None, None)
+
+    def _ray_lateral_range(self, pg_world, start_position, dir, length=50):
+        """
+        It is used to measure the lateral range of special blocks
+        :param start_position: start_point
+        :param dir: ray direction
+        :param length: length of ray
+        :return: lateral range [m]
+        """
+        end_position = start_position[0]+dir[0]*length, start_position[1]+dir[1]*length
+        start_position = panda_position(start_position, z=0.15)
+        end_position = panda_position(end_position, z=0.15)
+        mask = BitMask32.bit(FirstBlock.CONTINUOUS_COLLISION_MASK)
+        res = pg_world.physics_world.static_world.rayTestClosest(start_position, end_position, mask=mask)
+        if not res.hasHit():
+            return length
+        else:
+            return res.getHitFraction()*length
+

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -251,6 +251,4 @@ class RoutingLocalizationModule:
         for lane, index, l_1_dist in possible_lanes:
             if lane in self.current_ref_lanes:
                 return lane, index
-        return possible_lanes[0][:-1] if len(possible_lanes)>0 else (None, None)
-
-
+        return possible_lanes[0][:-1] if len(possible_lanes) > 0 else (None, None)

--- a/pgdrive/scene_creator/vehicle_module/routing_localization.py
+++ b/pgdrive/scene_creator/vehicle_module/routing_localization.py
@@ -102,7 +102,7 @@ class RoutingLocalizationModule:
         target_road_1_start = self.checkpoints[0]
         target_road_1_end = self.checkpoints[1]
         self.current_ref_lanes = self.map.road_network.graph[target_road_1_start][target_road_1_end]
-        self.current_road = Road(target_road_1_start,target_road_1_end)
+        self.current_road = Road(target_road_1_start, target_road_1_end)
 
     def update_navigation_localization(self, ego_vehicle):
         position = ego_vehicle.position
@@ -125,7 +125,7 @@ class RoutingLocalizationModule:
         target_lanes_1 = self.map.road_network.graph[target_road_1_start][target_road_1_end]
         target_lanes_2 = self.map.road_network.graph[target_road_2_start][target_road_2_end]
         self.current_ref_lanes = target_lanes_1
-        self.current_road = Road(target_road_1_start,target_road_1_end)
+        self.current_road = Road(target_road_1_start, target_road_1_end)
 
         self._navi_info.fill(0.0)
         half = self.navigation_info_dim // 2
@@ -249,7 +249,7 @@ class RoutingLocalizationModule:
             left_lane = self.current_ref_lanes[0]
             assert isinstance(left_lane, StraightLane), "Reference lane should be straight lane here"
             long, lat = left_lane.local_coordinates(current_position)
-            current_position = left_lane.position(long, -left_lane.width/2)
+            current_position = left_lane.position(long, -left_lane.width / 2)
             return self._ray_lateral_range(pg_world, current_position, self.current_ref_lanes[0].direction_lateral)
         else:
             return self.get_current_lane_width() * self.get_current_lane_num()
@@ -275,7 +275,7 @@ class RoutingLocalizationModule:
         :param length: length of ray
         :return: lateral range [m]
         """
-        end_position = start_position[0]+dir[0]*length, start_position[1]+dir[1]*length
+        end_position = start_position[0] + dir[0] * length, start_position[1] + dir[1] * length
         start_position = panda_position(start_position, z=0.15)
         end_position = panda_position(end_position, z=0.15)
         mask = BitMask32.bit(FirstBlock.CONTINUOUS_COLLISION_MASK)
@@ -283,5 +283,4 @@ class RoutingLocalizationModule:
         if not res.hasHit():
             return length
         else:
-            return res.getHitFraction()*length
-
+            return res.getHitFraction() * length

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -60,7 +60,8 @@ if __name__ == "__main__":
                 "reward": r,
                 "lane_index": env.vehicle.lane_index,
                 "dist_to_left": env.vehicle.dist_to_left,
-                "dist_to_right": env.vehicle.dist_to_right
+                "dist_to_right": env.vehicle.dist_to_right,
+                "out_of_route":env.vehicle.out_of_route
             }
         )
         # if d:

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -29,7 +29,7 @@ class TestEnv(PGDriveEnv):
                 "fast": False,
                 "map_config": {
                     Map.GENERATE_TYPE: MapGenerateMethod.BIG_BLOCK_SEQUENCE,
-                    Map.GENERATE_CONFIG: "TXOrR",
+                    Map.GENERATE_CONFIG: "Yy",
                     Map.LANE_WIDTH: 3.5,
                     Map.LANE_NUM: 3,
                 },

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
                 "lane_index": env.vehicle.lane_index,
                 "dist_to_left": env.vehicle.dist_to_left,
                 "dist_to_right": env.vehicle.dist_to_right,
-                "out_of_route":env.vehicle.out_of_route
+                "out_of_route": env.vehicle.out_of_route
             }
         )
         # if d:

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -28,8 +28,8 @@ class TestEnv(PGDriveEnv):
                 "debug": True,
                 "fast": False,
                 "map_config": {
-                    Map.GENERATE_TYPE: MapGenerateMethod.BIG_BLOCK_NUM,
-                    Map.GENERATE_CONFIG: 20,
+                    Map.GENERATE_TYPE: MapGenerateMethod.BIG_BLOCK_SEQUENCE,
+                    Map.GENERATE_CONFIG: "TXO",
                     Map.LANE_WIDTH: 3.5,
                     Map.LANE_NUM: 3,
                 },
@@ -55,14 +55,12 @@ if __name__ == "__main__":
     for i in range(1, 100000):
         o, r, d, info = env.step([1.0, 0.])
         info["fuel"] = env.vehicle.energy_consumption
-        # env.render(
-        #     text={
-        #         "left": env.vehicle.dist_to_left,
-        #         "right": env.vehicle.dist_to_right,
-        #         "white_lane_line": env.vehicle.on_white_continuous_line,
-        #         "reward": r,
-        #     }
-        # )
+        env.render(
+            text={
+                "reward": r,
+                "lane_index":env.vehicle.lane_index
+            }
+        )
         # if d:
         #     print("Reset")
         #     env.reset()

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -58,9 +58,9 @@ if __name__ == "__main__":
         env.render(
             text={
                 "reward": r,
-                "lane_index":env.vehicle.lane_index,
-                "dist_to_left":env.vehicle.dist_to_left,
-                "dist_to_right":env.vehicle.dist_to_right
+                "lane_index": env.vehicle.lane_index,
+                "dist_to_left": env.vehicle.dist_to_left,
+                "dist_to_right": env.vehicle.dist_to_right
             }
         )
         # if d:

--- a/pgdrive/tests/vis_env/vis_pgdrive_env.py
+++ b/pgdrive/tests/vis_env/vis_pgdrive_env.py
@@ -29,7 +29,7 @@ class TestEnv(PGDriveEnv):
                 "fast": False,
                 "map_config": {
                     Map.GENERATE_TYPE: MapGenerateMethod.BIG_BLOCK_SEQUENCE,
-                    Map.GENERATE_CONFIG: "TXO",
+                    Map.GENERATE_CONFIG: "TXOrR",
                     Map.LANE_WIDTH: 3.5,
                     Map.LANE_NUM: 3,
                 },
@@ -58,7 +58,9 @@ if __name__ == "__main__":
         env.render(
             text={
                 "reward": r,
-                "lane_index":env.vehicle.lane_index
+                "lane_index":env.vehicle.lane_index,
+                "dist_to_left":env.vehicle.dist_to_left,
+                "dist_to_right":env.vehicle.dist_to_right
             }
         )
         # if d:

--- a/pgdrive/utils/scene_utils.py
+++ b/pgdrive/utils/scene_utils.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, TYPE_CHECKING, Tuple
+from typing import List, TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 from pgdrive.constants import Decoration, BodyName
@@ -20,7 +20,7 @@ def get_lanes_on_road(road: "Road", roadnet: "RoadNetwork") -> List["AbstractLan
 
 
 def block_socket_merge(
-    socket_1: "BlockSocket", socket_2: "BlockSocket", global_network: "RoadNetwork", positive_merge: False
+        socket_1: "BlockSocket", socket_2: "BlockSocket", global_network: "RoadNetwork", positive_merge: False
 ):
     global_network.graph[socket_1.positive_road.start_node][socket_2.negative_road.start_node] = \
         global_network.graph[socket_1.positive_road.start_node].pop(socket_1.positive_road.end_node)
@@ -122,13 +122,14 @@ def get_all_lanes(roadnet: "RoadNetwork"):
     return res
 
 
-def ray_localization(position: np.ndarray, pg_world: PGWorld) -> Tuple:
+def ray_localization(position: np.ndarray, pg_world: PGWorld, all_result=False) -> Union[List[Tuple], Tuple]:
     """
     Get the index of the lane closest to a physx_world position.
     Only used when smoething is on lane ! Otherwise fall back to use get_closest_lane()
     :param position: a physx_world position [m].
     :param pg_world: PGWorld class
-    :return: the index of the closest lane.
+    :param all_result: return a list instead of the lane with min L1 distance
+    :return: list(closest lane) or closest lane.
     """
     results = pg_world.physics_world.static_world.rayTestAll(
         panda_position(position, 1.0), panda_position(position, -1.0)
@@ -139,9 +140,17 @@ def ray_localization(position: np.ndarray, pg_world: PGWorld) -> Tuple:
             if res.getNode().getName() == BodyName.Lane:
                 lane = res.getNode().getPythonTag(BodyName.Lane)
                 lane_index_dist.append((lane.info, lane.index, lane.info.distance(position)))
-    if len(lane_index_dist) > 0:
-        ret_index = np.argmin([d for _, _, d in lane_index_dist])
-        lane, index, dist = lane_index_dist[ret_index]
+    if all_result:
+        ret = []
+        if len(lane_index_dist) > 0:
+            for lane, index, dist in lane_index_dist:
+                ret.append((lane, index, dist))
+        sorted(ret, key=lambda k:k[2])
+        return ret
     else:
-        lane, index, dist = None, None, None
-    return lane, index
+        if len(lane_index_dist) > 0:
+            ret_index = np.argmin([d for _, _, d in lane_index_dist])
+            lane, index, dist = lane_index_dist[ret_index]
+        else:
+            lane, index, dist = None, None, None
+        return lane, index

--- a/pgdrive/utils/scene_utils.py
+++ b/pgdrive/utils/scene_utils.py
@@ -122,13 +122,13 @@ def get_all_lanes(roadnet: "RoadNetwork"):
     return res
 
 
-def ray_localization(position: np.ndarray, pg_world: PGWorld, all_result=False) -> Union[List[Tuple], Tuple]:
+def ray_localization(position: np.ndarray, pg_world: PGWorld, return_all_result=False) -> Union[List[Tuple], Tuple]:
     """
     Get the index of the lane closest to a physx_world position.
     Only used when smoething is on lane ! Otherwise fall back to use get_closest_lane()
     :param position: a physx_world position [m].
     :param pg_world: PGWorld class
-    :param all_result: return a list instead of the lane with min L1 distance
+    :param return_all_result: return a list instead of the lane with min L1 distance
     :return: list(closest lane) or closest lane.
     """
     results = pg_world.physics_world.static_world.rayTestAll(
@@ -140,7 +140,7 @@ def ray_localization(position: np.ndarray, pg_world: PGWorld, all_result=False) 
             if res.getNode().getName() == BodyName.Lane:
                 lane = res.getNode().getPythonTag(BodyName.Lane)
                 lane_index_dist.append((lane.info, lane.index, lane.info.distance(position)))
-    if all_result:
+    if return_all_result:
         ret = []
         if len(lane_index_dist) > 0:
             for lane, index, dist in lane_index_dist:

--- a/pgdrive/utils/scene_utils.py
+++ b/pgdrive/utils/scene_utils.py
@@ -20,7 +20,7 @@ def get_lanes_on_road(road: "Road", roadnet: "RoadNetwork") -> List["AbstractLan
 
 
 def block_socket_merge(
-        socket_1: "BlockSocket", socket_2: "BlockSocket", global_network: "RoadNetwork", positive_merge: False
+    socket_1: "BlockSocket", socket_2: "BlockSocket", global_network: "RoadNetwork", positive_merge: False
 ):
     global_network.graph[socket_1.positive_road.start_node][socket_2.negative_road.start_node] = \
         global_network.graph[socket_1.positive_road.start_node].pop(socket_1.positive_road.end_node)
@@ -145,7 +145,7 @@ def ray_localization(position: np.ndarray, pg_world: PGWorld, all_result=False) 
         if len(lane_index_dist) > 0:
             for lane, index, dist in lane_index_dist:
                 ret.append((lane, index, dist))
-        sorted(ret, key=lambda k:k[2])
+        sorted(ret, key=lambda k: k[2])
         return ret
     else:
         if len(lane_index_dist) > 0:


### PR DESCRIPTION
## What changes do you make in this PR?

- RayCast Lane localization will first find the lanes in the routing module.
- It can help solve the reward problem in intersections and roundabout. 

## Checklist

* [ ] I have merged the latest main branch into current branch.
* [ ] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
